### PR TITLE
What: make matplotlib required

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "PIANO: Probabilistic Inference Autoencoder Networks for multi-Omi
 readme = "README.md"
 requires-python = ">=3.10.18"
 dependencies = [
+    "matplotlib",
     "numpy>=2",
     "pandas",
     "scipy",
@@ -43,7 +44,6 @@ misc = [
     "torch>=2.2,<2.8",
     "igraph",
     "leidenalg",
-    "matplotlib",
     "seaborn",
     "joblib",
     "jupyterlab",

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 # Machine learning imports
+matplotlib
 numpy>=2
 pandas
 scipy
@@ -45,7 +46,6 @@ scib-metrics==0.5.3
 rapids-singlecell[rapids12]==0.13.1
 
 # Optional miscellaneous utilities
-matplotlib
 seaborn
 joblib
 jupyterlab

--- a/requirements_lite.txt
+++ b/requirements_lite.txt
@@ -19,6 +19,7 @@
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 # Machine learning imports
+matplotlib
 numpy>=2
 pandas
 scipy

--- a/requirements_rapids.txt
+++ b/requirements_rapids.txt
@@ -19,6 +19,7 @@
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 # Machine learning imports
+matplotlib
 numpy>=2
 pandas
 scipy

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ extra_reqs = {
     'misc': [
         'igraph',
         'leidenalg',
-        'matplotlib',
         'seaborn',
         'joblib',
         'jupyterlab',
@@ -53,6 +52,7 @@ setup(
     version='0.0.1',
     packages=find_packages(),
     install_requires=[
+        'matplotlib',
         'numpy>=2',
         'pandas',
         'scipy',


### PR DESCRIPTION
Why: Too commonly used not to include
How: Move from optional to hard dependency
Testing: Installs via test PyPI