### PR TITLE
What: Fix load_model device bug

### DIFF
--- a/piano/utils/composer.py
+++ b/piano/utils/composer.py
@@ -284,9 +284,10 @@ class Composer():
             Loads the model weights from specified checkpoint to specified device.
             This also sets the model to eval mode. To continue training, set .train()
         """
+        self.model.load_state_dict(torch.load(model_checkpoint_path, map_location=device, weights_only=True))
         self.device = device
-        self.model.to(self.device)
-        self.model.load_state_dict(torch.load(model_checkpoint_path, map_location=self.device, weights_only=True))
+        self.model.device = device
+        self.model.to(device)
         self.model.eval()
 
         return self.model


### PR DESCRIPTION
Why: loading model was not setting the model (e.g., Etude device attribute) and not calling .to(device) after loading weights, which means the actual device may have differed. The self.model.device parameter may cause conflicting behavior.
How: Set the self.device in Composer, and also self.model.device, and call .to(device) explicity after loading weights
Testing: Now gives correct device