### PR TITLE
What: Publish as version 0.1.8

### DIFF
--- a/piano/__init__.py
+++ b/piano/__init__.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # piano/__init__.py
 
 # Define package version
-__version__ = '0.1.9'
+__version__ = '0.1.8'
 
 # Import all modules
 from .models.base_models import Etude, EtudeMuTheta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "piano-integration"
-version = "0.1.9"
+version = "0.1.8"
 description = "PIANO: Probabilistic Inference Autoencoder Networks for multi-Omics"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ with open('README.md', mode='r') as readme:
 
 setup(
     name='PIANO',
-    version='0.1.9',
+    version='0.1.8',
     packages=find_packages(),
     install_requires=[
         # Machine learning imports


### PR DESCRIPTION
Why: Keep PyPI versioning consistent
How: Set version to 0.1.8 instead of 0.1.9
Testing: Runs as expected