### PR TITLE
What: Fix memory leak

### DIFF
--- a/piano/utils/composer.py
+++ b/piano/utils/composer.py
@@ -784,11 +784,12 @@ class Composer():
             total_ = losses_dict[training_metric]
 
             # Backward pass
-            optimizer.zero_grad()
+            optimizer.zero_grad(set_to_none=True)  # Should already be default but make explicit
             total_.backward()
             optimizer.step()
 
-            return losses_dict
+            metrics = {k: v.item() for k, v in losses_dict.items()}  # Detaches from compute graph
+            return metrics
 
         if torch.cuda.is_available() and self.compile_model:
             compiled_train_step = torch.compile(train_step, mode='max-autotune')  # , fullgraph=True)

--- a/run_piano_integration.py
+++ b/run_piano_integration.py
@@ -16,8 +16,8 @@ from piano import Composer, time_code, highly_variable_genes
 try:
     import rapids_singlecell as rsc
     # sc.pp.pca = rsc.pp.pca  # Can sometimes run out of memory for large datasets if using rsc
-    sc.pp.neighbors = rsc.pp.neighbors
-    sc.tl.umap = rsc.tl.umap
+    # sc.pp.neighbors = rsc.pp.neighbors
+    # sc.tl.umap = rsc.tl.umap
     print('Using rapids singlecell to speed up pca, neighbors, and umap', flush=True)
 except:
     print('Warning: Unable to use rapids singlecell in this environment', flush=True)


### PR DESCRIPTION
Why: memory was leaking every training epoch, resulting in huge memory consumption
How: Avoid storing all compute graphs by using .item() to extract loss values as python floats
Testing: using psutil, no longer shows increase every epoch