### PR TITLE
What: Fix graph break

### DIFF
--- a/piano/utils/composer.py
+++ b/piano/utils/composer.py
@@ -788,7 +788,7 @@ class Composer():
             total_.backward()
             optimizer.step()
 
-            metrics = {k: v.item() for k, v in losses_dict.items()}  # Detaches from compute graph
+            metrics = {k: v.detach() for k, v in losses_dict.items()}  # Detaches from compute graph
             return metrics
 
         if torch.cuda.is_available() and self.compile_model:

--- a/run_piano_integration.py
+++ b/run_piano_integration.py
@@ -16,8 +16,8 @@ from piano import Composer, time_code, highly_variable_genes
 try:
     import rapids_singlecell as rsc
     # sc.pp.pca = rsc.pp.pca  # Can sometimes run out of memory for large datasets if using rsc
-    # sc.pp.neighbors = rsc.pp.neighbors
-    # sc.tl.umap = rsc.tl.umap
+    sc.pp.neighbors = rsc.pp.neighbors
+    sc.tl.umap = rsc.tl.umap
     print('Using rapids singlecell to speed up pca, neighbors, and umap', flush=True)
 except:
     print('Warning: Unable to use rapids singlecell in this environment', flush=True)


### PR DESCRIPTION
Why: Avoid unnecessary slow down due to graph break
How: replace .item call with .detach, which avoids breaking the graph in train_step
Testing: No longer receive graph break warning and slight speedup