### PR TITLE
What: Return no-adversarial loss as tensor

### DIFF
--- a/piano/models/base_models.py
+++ b/piano/models/base_models.py
@@ -289,7 +289,7 @@ class Etude(nn.Module):
         kld_loss = self._kld_loss(posterior_latent, posterior_dist)
         nll_loss = self._nll_loss(nb_ksi, nb_psi, x_raw, zi_dropout_logits)
 
-        return {'nll': nll_loss, 'kld': kld_loss, 'adv': 0}
+        return {'nll': nll_loss, 'kld': kld_loss, 'adv': torch.zeros_like(nll_loss)}
 
     def training_step(self, batch, kld_weight, adv_weight):
         losses_dict = self.forward(batch)


### PR DESCRIPTION
Why: When adversarial=False, _forward_no_adv returns adv=0 as a Python integer, but the compiled training loop calls .detach() on all returned losses, causing an AttributeError.

How: Return adv as a zero-valued tensor.

Testing: Tested on MERFISH data with compile_model=True and adversarial=False; training runs to completion in ~12 min.